### PR TITLE
having gdar compiling and running against libdar released with 2.6.1

### DIFF
--- a/src/change_namespace.sh
+++ b/src/change_namespace.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-for file in `ls *.?pp` ; do
-    mv "$file" "$file.bak"
-    sed -r 's/libdar\:\:/libdar5\:\:/g' < "$file.bak" > "$file"
-done

--- a/src/change_namespace.sh
+++ b/src/change_namespace.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+for file in `ls *.?pp` ; do
+    mv "$file" "$file.bak"
+    sed -r 's/libdar\:\:/libdar5\:\:/g' < "$file.bak" > "$file"
+done

--- a/src/enc_dialog.cpp
+++ b/src/enc_dialog.cpp
@@ -57,25 +57,25 @@ EncSettings::EncSettings(Gtk::Window &parent) :
    show_all_children();
 }
 
-libdar::secu_string EncSettings::get_pass() {
-    return libdar::secu_string(p_entry.get_text().c_str(),p_entry.get_text().length());
+libdar5::secu_string EncSettings::get_pass() {
+    return libdar5::secu_string(p_entry.get_text().c_str(),p_entry.get_text().length());
 }
 
 int EncSettings::get_block_size() {
     return (int)b_spinb.get_value();
 }
 
-libdar::crypto_algo EncSettings::get_crypt_algo() {
+libdar5::crypto_algo EncSettings::get_crypt_algo() {
     if (blowfish_check.get_active())
-        return libdar::crypto_blowfish;
+        return libdar5::crypto_blowfish;
     if (aes_check.get_active())
-        return libdar::crypto_aes256 ;
+        return libdar5::crypto_aes256 ;
     if (twofish_check.get_active())
-        return libdar::crypto_twofish256;
+        return libdar5::crypto_twofish256;
     if (serpent_check.get_active())
-        return libdar::crypto_serpent256;
+        return libdar5::crypto_serpent256;
     if (camellia_check.get_active())
-        return libdar::crypto_camellia256;
-    return libdar::crypto_none;
+        return libdar5::crypto_camellia256;
+    return libdar5::crypto_none;
 }
 

--- a/src/enc_dialog.cpp
+++ b/src/enc_dialog.cpp
@@ -57,25 +57,25 @@ EncSettings::EncSettings(Gtk::Window &parent) :
    show_all_children();
 }
 
-libdar5::secu_string EncSettings::get_pass() {
-    return libdar5::secu_string(p_entry.get_text().c_str(),p_entry.get_text().length());
+LIBDAR::secu_string EncSettings::get_pass() {
+    return LIBDAR::secu_string(p_entry.get_text().c_str(),p_entry.get_text().length());
 }
 
 int EncSettings::get_block_size() {
     return (int)b_spinb.get_value();
 }
 
-libdar5::crypto_algo EncSettings::get_crypt_algo() {
+LIBDAR::crypto_algo EncSettings::get_crypt_algo() {
     if (blowfish_check.get_active())
-        return libdar5::crypto_blowfish;
+        return LIBDAR::crypto_blowfish;
     if (aes_check.get_active())
-        return libdar5::crypto_aes256 ;
+        return LIBDAR::crypto_aes256 ;
     if (twofish_check.get_active())
-        return libdar5::crypto_twofish256;
+        return LIBDAR::crypto_twofish256;
     if (serpent_check.get_active())
-        return libdar5::crypto_serpent256;
+        return LIBDAR::crypto_serpent256;
     if (camellia_check.get_active())
-        return libdar5::crypto_camellia256;
-    return libdar5::crypto_none;
+        return LIBDAR::crypto_camellia256;
+    return LIBDAR::crypto_none;
 }
 

--- a/src/enc_dialog.hpp
+++ b/src/enc_dialog.hpp
@@ -27,7 +27,6 @@
 #include <glibmm/i18n.h>
 #ifdef LIBDAR5
 #include <dar/libdar5.hpp>
-namespace libdar = libdar5;
 #else
 #include <dar/libdar.hpp>
 #endif

--- a/src/enc_dialog.hpp
+++ b/src/enc_dialog.hpp
@@ -35,9 +35,9 @@ namespace libdar = libdar5;
 class EncSettings : public Gtk::Dialog {
 public:
     EncSettings(Gtk::Window &parent);
-    libdar::secu_string get_pass();
+    libdar5::secu_string get_pass();
     int get_block_size();
-    libdar::crypto_algo get_crypt_algo();
+    libdar5::crypto_algo get_crypt_algo();
 
 private:
     Gtk::Box *cont_box;

--- a/src/enc_dialog.hpp
+++ b/src/enc_dialog.hpp
@@ -25,6 +25,8 @@
 
 #include <gtkmm.h>
 #include <glibmm/i18n.h>
+
+#include "config.h"
 #ifdef LIBDAR5
 #include <dar/libdar5.hpp>
 #else

--- a/src/libdar_namespace.hpp
+++ b/src/libdar_namespace.hpp
@@ -16,41 +16,21 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
     To contact the author: https://github.com/peckto/gdar
+
 */
 
-#ifndef ENC_DIALOG_HPP
-#define ENC_DIALOG_HPP
-
-#define DEFAULT_BLOCK_SIZE 10240
-
-#include <gtkmm.h>
-#include <glibmm/i18n.h>
+#ifndef LIBDAR_NAMESPACE_HPP
+#define LIBDAR_NAMESPACE_HPP
 
 #include "config.h"
-#include "libdar_namespace.hpp"
 
-class EncSettings : public Gtk::Dialog {
-public:
-    EncSettings(Gtk::Window &parent);
-    LIBDAR::secu_string get_pass();
-    int get_block_size();
-    LIBDAR::crypto_algo get_crypt_algo();
+#ifdef LIBDAR5
+#include <dar/libdar5.hpp>
+#define LIBDAR libdar5
+#else
+#include <dar/libdar.hpp>
+#define LIBDAR libdar
+#endif
 
-private:
-    Gtk::Box *cont_box;
-    Gtk::Box m_box, b_box, p_box;
 
-    Gtk::Label p_lable, c_lable, b_lable;
-
-    Gtk::Grid c_grid;
-    Gtk::Entry p_entry;
-    Gtk::SpinButton b_spinb;
-
-    Gtk::RadioButtonGroup algo_group;
-    Gtk::RadioButton blowfish_check, aes_check, twofish_check, serpent_check, camellia_check;
-
-    Gtk::Button ok_button, c_button;
-
-};
-
-#endif // ENC_DIALOG_HPP
+#endif

--- a/src/libgdar.cpp
+++ b/src/libgdar.cpp
@@ -169,10 +169,10 @@ GdarOpenWindow::GdarOpenWindow(GdarApplication *application) : Window()
     show_all_children();
 
     // init libdar
-    libdar::U_I maj, med, min;
-    libdar::get_version(maj, med, min);
+    libdar5::U_I maj, med, min;
+    libdar5::get_version(maj, med, min);
 
-    if(maj != libdar::LIBDAR_COMPILE_TIME_MAJOR || med < libdar::LIBDAR_COMPILE_TIME_MEDIUM) {
+    if(maj != libdar5::LIBDAR_COMPILE_TIME_MAJOR || med < libdar5::LIBDAR_COMPILE_TIME_MEDIUM) {
         std::cout << "we are linking against a wrong libdar" << std::endl; // TODO dialog
         Gtk::Main::quit();
     }
@@ -180,7 +180,7 @@ GdarOpenWindow::GdarOpenWindow(GdarApplication *application) : Window()
 }
 
 GdarOpenWindow::~GdarOpenWindow() { 
-    libdar::close_and_clean();
+    libdar5::close_and_clean();
 
     if ( extract_stats != NULL )
         delete extract_stats;
@@ -191,7 +191,7 @@ bool GdarOpenWindow::openDar() {
         newDar->init();
         newDar->setListingBuffer(&listingBuffer);
         newDar->open(path,slice,read_options); 
-    } catch (libdar::Egeneric &e) {
+    } catch (libdar5::Egeneric &e) {
         {
             Glib::Mutex::Lock lock(errorMutex);
             ErrorMsg emsg(e);
@@ -200,17 +200,17 @@ bool GdarOpenWindow::openDar() {
         }
         return false;
     }
-    extract_stats = new libdar::statistics(true);
+    extract_stats = new libdar5::statistics(true);
     is_open = true;
     return true;
 }
 
 #ifdef GET_CHILDREN_IN_TABLE
-void GdarOpenWindow::populate(std::vector<libdar::list_entry> *children_table) {
+void GdarOpenWindow::populate(std::vector<libdar5::list_entry> *children_table) {
     Gtk::TreeModel::Row row;
     listStore->clear();
     int size;
-    for (std::vector<libdar::list_entry>::iterator it = children_table->begin();it != children_table->end();it++) {
+    for (std::vector<libdar5::list_entry>::iterator it = children_table->begin();it != children_table->end();it++) {
         row = *(listStore->append());
         row[cols.file_name] = it->get_name();
         row[cols.file_is_dir] = it->is_dir();
@@ -340,14 +340,14 @@ int GdarOpenWindow::list_children() {
     string s_treePath = get_treePath();
     try {
 #ifdef GET_CHILDREN_IN_TABLE
-        std::vector<libdar::list_entry> children_table = newDar->get_children_in_table(s_treePath);
+        std::vector<libdar5::list_entry> children_table = newDar->get_children_in_table(s_treePath);
         populate(&children_table);
 #else
         listingBuffer.clear();
         newDar->list_children(s_treePath.c_str());
         populate();
 #endif
-    } catch (libdar::Egeneric &e) {
+    } catch (libdar5::Egeneric &e) {
         {
             Glib::Mutex::Lock lock(errorMutex);
             ErrorMsg emsg(e);
@@ -453,15 +453,15 @@ void GdarOpenWindow::on_button_open() {
 
 void GdarOpenWindow::open(string &filename, EncSettings *encSettins) {
     create_mydar();
-    libdar::secu_string tmp_pass;
-    libdar::U_32 crypto_size = DEFAULT_CRYPTO_SIZE;
+    libdar5::secu_string tmp_pass;
+    libdar5::U_32 crypto_size = DEFAULT_CRYPTO_SIZE;
 
     if (encSettins != NULL ) {
         read_options->set_crypto_size(encSettins->get_block_size());
         read_options->set_crypto_pass(encSettins->get_pass());
         read_options->set_crypto_algo(encSettins->get_crypt_algo());
     } else {
-    //    read_options->set_crypto_algo(libdar::crypto_none);
+    //    read_options->set_crypto_algo(libdar5::crypto_none);
 //	read_options->set_crypto_pass(tmp_pass);
  //       read_options->set_crypto_size(crypto_size);
 
@@ -486,7 +486,7 @@ void GdarOpenWindow::create_mydar() {
     if (read_options != NULL) {
         delete read_options;
     }
-    read_options = new libdar::archive_options_read;
+    read_options = new libdar5::archive_options_read;
     newDar = new Mydar(this);
     n_entry_path.set_text("");
     treePath.clear();
@@ -532,7 +532,7 @@ void GdarOpenWindow::extractThread() {
     m_spinner.start();
     try {
         newDar->extract(ext_src.c_str(),ext_dest.c_str(),extract_stats);
-    } catch (libdar::Egeneric &e) {
+    } catch (libdar5::Egeneric &e) {
         {
             Glib::Mutex::Lock lock(errorMutex);
             ErrorMsg emsg(e);
@@ -550,14 +550,14 @@ void GdarOpenWindow::extractThread() {
 void GdarOpenWindow::on_extract_finish() {
     std::map<std::string, std::string> stats;
 
-    stats[_("Treated files")] = libdar::deci(extract_stats->get_treated()).human();
-//    stats[_("Hard links")] = libdar::deci(extract_stats->get_hard_links()).human();
-    stats[_("Skipped files")] = libdar::deci(extract_stats->get_skipped()).human();
-    stats[_("Ignored files")] = libdar::deci(extract_stats->get_ignored()).human();
-//    stats[_("tooold")] = libdar::deci(extract_stats->get_tooold()).human();
-    stats[_("Errored files")] = libdar::deci(extract_stats->get_errored()).human();
-//    stats[_("ea_treated")] = libdar::deci(extract_stats->get_ea_treated()).human();
-//    stats[_("Processed bytes")] = libdar::deci(extract_stats->get_byte_amount()).human();
+    stats[_("Treated files")] = libdar5::deci(extract_stats->get_treated()).human();
+//    stats[_("Hard links")] = libdar5::deci(extract_stats->get_hard_links()).human();
+    stats[_("Skipped files")] = libdar5::deci(extract_stats->get_skipped()).human();
+    stats[_("Ignored files")] = libdar5::deci(extract_stats->get_ignored()).human();
+//    stats[_("tooold")] = libdar5::deci(extract_stats->get_tooold()).human();
+    stats[_("Errored files")] = libdar5::deci(extract_stats->get_errored()).human();
+//    stats[_("ea_treated")] = libdar5::deci(extract_stats->get_ea_treated()).human();
+//    stats[_("Processed bytes")] = libdar5::deci(extract_stats->get_byte_amount()).human();
 
     string msg = ext_src;
     msg += " => ";
@@ -572,11 +572,11 @@ void GdarOpenWindow::on_info() {
         return;
 //    m_spinner.start();
     std::map<std::string, std::string> stats;
-    libdar::entree_stats my_stats = newDar->my_arch->get_stats();
-    stats[_("Total numer of inodes")] = libdar::deci(my_stats.total).human();
-    stats[_("Number of directories")] = libdar::deci(my_stats.num_d).human();
-    stats[_("Number of files")] = libdar::deci(my_stats.num_f).human();
-    stats[_("Saved inodes in this backup")] = libdar::deci(my_stats.saved).human();
+    libdar5::entree_stats my_stats = newDar->my_arch->get_stats();
+    stats[_("Total numer of inodes")] = libdar5::deci(my_stats.total).human();
+    stats[_("Number of directories")] = libdar5::deci(my_stats.num_d).human();
+    stats[_("Number of files")] = libdar5::deci(my_stats.num_f).human();
+    stats[_("Saved inodes in this backup")] = libdar5::deci(my_stats.saved).human();
 
     TableDialog dlg("",stats);
     dlg.set_title(_("About ") + slice);
@@ -715,7 +715,7 @@ ErrorMsg::ErrorMsg(Glib::ustring msg, Glib::ustring source) {
     this->msg = msg;
     this->source = source;
 }
-ErrorMsg::ErrorMsg(libdar::Egeneric &e) {
+ErrorMsg::ErrorMsg(libdar5::Egeneric &e) {
     msg = e.get_message();
     source = e.get_source();
 }

--- a/src/libgdar.cpp
+++ b/src/libgdar.cpp
@@ -169,10 +169,10 @@ GdarOpenWindow::GdarOpenWindow(GdarApplication *application) : Window()
     show_all_children();
 
     // init libdar
-    libdar5::U_I maj, med, min;
-    libdar5::get_version(maj, med, min);
+    LIBDAR::U_I maj, med, min;
+    LIBDAR::get_version(maj, med, min);
 
-    if(maj != libdar5::LIBDAR_COMPILE_TIME_MAJOR || med < libdar5::LIBDAR_COMPILE_TIME_MEDIUM) {
+    if(maj != LIBDAR::LIBDAR_COMPILE_TIME_MAJOR || med < LIBDAR::LIBDAR_COMPILE_TIME_MEDIUM) {
         std::cout << "we are linking against a wrong libdar" << std::endl; // TODO dialog
         Gtk::Main::quit();
     }
@@ -180,7 +180,7 @@ GdarOpenWindow::GdarOpenWindow(GdarApplication *application) : Window()
 }
 
 GdarOpenWindow::~GdarOpenWindow() { 
-    libdar5::close_and_clean();
+    LIBDAR::close_and_clean();
 
     if ( extract_stats != NULL )
         delete extract_stats;
@@ -191,7 +191,7 @@ bool GdarOpenWindow::openDar() {
         newDar->init();
         newDar->setListingBuffer(&listingBuffer);
         newDar->open(path,slice,read_options); 
-    } catch (libdar5::Egeneric &e) {
+    } catch (LIBDAR::Egeneric &e) {
         {
             Glib::Mutex::Lock lock(errorMutex);
             ErrorMsg emsg(e);
@@ -200,17 +200,17 @@ bool GdarOpenWindow::openDar() {
         }
         return false;
     }
-    extract_stats = new libdar5::statistics(true);
+    extract_stats = new LIBDAR::statistics(true);
     is_open = true;
     return true;
 }
 
 #ifdef GET_CHILDREN_IN_TABLE
-void GdarOpenWindow::populate(std::vector<libdar5::list_entry> *children_table) {
+void GdarOpenWindow::populate(std::vector<LIBDAR::list_entry> *children_table) {
     Gtk::TreeModel::Row row;
     listStore->clear();
     int size;
-    for (std::vector<libdar5::list_entry>::iterator it = children_table->begin();it != children_table->end();it++) {
+    for (std::vector<LIBDAR::list_entry>::iterator it = children_table->begin();it != children_table->end();it++) {
         row = *(listStore->append());
         row[cols.file_name] = it->get_name();
         row[cols.file_is_dir] = it->is_dir();
@@ -340,14 +340,14 @@ int GdarOpenWindow::list_children() {
     string s_treePath = get_treePath();
     try {
 #ifdef GET_CHILDREN_IN_TABLE
-        std::vector<libdar5::list_entry> children_table = newDar->get_children_in_table(s_treePath);
+        std::vector<LIBDAR::list_entry> children_table = newDar->get_children_in_table(s_treePath);
         populate(&children_table);
 #else
         listingBuffer.clear();
         newDar->list_children(s_treePath.c_str());
         populate();
 #endif
-    } catch (libdar5::Egeneric &e) {
+    } catch (LIBDAR::Egeneric &e) {
         {
             Glib::Mutex::Lock lock(errorMutex);
             ErrorMsg emsg(e);
@@ -453,15 +453,15 @@ void GdarOpenWindow::on_button_open() {
 
 void GdarOpenWindow::open(string &filename, EncSettings *encSettins) {
     create_mydar();
-    libdar5::secu_string tmp_pass;
-    libdar5::U_32 crypto_size = DEFAULT_CRYPTO_SIZE;
+    LIBDAR::secu_string tmp_pass;
+    LIBDAR::U_32 crypto_size = DEFAULT_CRYPTO_SIZE;
 
     if (encSettins != NULL ) {
         read_options->set_crypto_size(encSettins->get_block_size());
         read_options->set_crypto_pass(encSettins->get_pass());
         read_options->set_crypto_algo(encSettins->get_crypt_algo());
     } else {
-    //    read_options->set_crypto_algo(libdar5::crypto_none);
+    //    read_options->set_crypto_algo(LIBDAR::crypto_none);
 //	read_options->set_crypto_pass(tmp_pass);
  //       read_options->set_crypto_size(crypto_size);
 
@@ -486,7 +486,7 @@ void GdarOpenWindow::create_mydar() {
     if (read_options != NULL) {
         delete read_options;
     }
-    read_options = new libdar5::archive_options_read;
+    read_options = new LIBDAR::archive_options_read;
     newDar = new Mydar(this);
     n_entry_path.set_text("");
     treePath.clear();
@@ -532,7 +532,7 @@ void GdarOpenWindow::extractThread() {
     m_spinner.start();
     try {
         newDar->extract(ext_src.c_str(),ext_dest.c_str(),extract_stats);
-    } catch (libdar5::Egeneric &e) {
+    } catch (LIBDAR::Egeneric &e) {
         {
             Glib::Mutex::Lock lock(errorMutex);
             ErrorMsg emsg(e);
@@ -550,14 +550,14 @@ void GdarOpenWindow::extractThread() {
 void GdarOpenWindow::on_extract_finish() {
     std::map<std::string, std::string> stats;
 
-    stats[_("Treated files")] = libdar5::deci(extract_stats->get_treated()).human();
-//    stats[_("Hard links")] = libdar5::deci(extract_stats->get_hard_links()).human();
-    stats[_("Skipped files")] = libdar5::deci(extract_stats->get_skipped()).human();
-    stats[_("Ignored files")] = libdar5::deci(extract_stats->get_ignored()).human();
-//    stats[_("tooold")] = libdar5::deci(extract_stats->get_tooold()).human();
-    stats[_("Errored files")] = libdar5::deci(extract_stats->get_errored()).human();
-//    stats[_("ea_treated")] = libdar5::deci(extract_stats->get_ea_treated()).human();
-//    stats[_("Processed bytes")] = libdar5::deci(extract_stats->get_byte_amount()).human();
+    stats[_("Treated files")] = LIBDAR::deci(extract_stats->get_treated()).human();
+//    stats[_("Hard links")] = LIBDAR::deci(extract_stats->get_hard_links()).human();
+    stats[_("Skipped files")] = LIBDAR::deci(extract_stats->get_skipped()).human();
+    stats[_("Ignored files")] = LIBDAR::deci(extract_stats->get_ignored()).human();
+//    stats[_("tooold")] = LIBDAR::deci(extract_stats->get_tooold()).human();
+    stats[_("Errored files")] = LIBDAR::deci(extract_stats->get_errored()).human();
+//    stats[_("ea_treated")] = LIBDAR::deci(extract_stats->get_ea_treated()).human();
+//    stats[_("Processed bytes")] = LIBDAR::deci(extract_stats->get_byte_amount()).human();
 
     string msg = ext_src;
     msg += " => ";
@@ -572,11 +572,11 @@ void GdarOpenWindow::on_info() {
         return;
 //    m_spinner.start();
     std::map<std::string, std::string> stats;
-    libdar5::entree_stats my_stats = newDar->my_arch->get_stats();
-    stats[_("Total numer of inodes")] = libdar5::deci(my_stats.total).human();
-    stats[_("Number of directories")] = libdar5::deci(my_stats.num_d).human();
-    stats[_("Number of files")] = libdar5::deci(my_stats.num_f).human();
-    stats[_("Saved inodes in this backup")] = libdar5::deci(my_stats.saved).human();
+    LIBDAR::entree_stats my_stats = newDar->my_arch->get_stats();
+    stats[_("Total numer of inodes")] = LIBDAR::deci(my_stats.total).human();
+    stats[_("Number of directories")] = LIBDAR::deci(my_stats.num_d).human();
+    stats[_("Number of files")] = LIBDAR::deci(my_stats.num_f).human();
+    stats[_("Saved inodes in this backup")] = LIBDAR::deci(my_stats.saved).human();
 
     TableDialog dlg("",stats);
     dlg.set_title(_("About ") + slice);
@@ -715,7 +715,7 @@ ErrorMsg::ErrorMsg(Glib::ustring msg, Glib::ustring source) {
     this->msg = msg;
     this->source = source;
 }
-ErrorMsg::ErrorMsg(libdar5::Egeneric &e) {
+ErrorMsg::ErrorMsg(LIBDAR::Egeneric &e) {
     msg = e.get_message();
     source = e.get_source();
 }

--- a/src/libgdar.hpp
+++ b/src/libgdar.hpp
@@ -39,7 +39,7 @@
 class ErrorMsg {
 public:
     ErrorMsg(Glib::ustring msg, Glib::ustring source);
-    ErrorMsg(libdar::Egeneric &e);
+    ErrorMsg(libdar5::Egeneric &e);
     Glib::ustring msg;
     Glib::ustring source;
 };
@@ -73,7 +73,7 @@ public:
     void openDarThread();
     void populate();
 #ifdef GET_CHILDREN_IN_TABLE
-    void populate(std::vector<libdar::list_entry> *children_table);
+    void populate(std::vector<libdar5::list_entry> *children_table);
 #endif
     void on_active_row(const Gtk::TreeModel::Path& path, Gtk::TreeViewColumn* column);
     void list_children_v();
@@ -111,12 +111,12 @@ protected:
     void create_mydar();
 
 private:
-    libdar::statistics *extract_stats;
+    libdar5::statistics *extract_stats;
     bool is_open;
 
     std::queue<ErrorMsg> errorPipe;
 
-    libdar::archive_options_read *read_options;
+    libdar5::archive_options_read *read_options;
 }; 
 
 class TableDialog : public Gtk::MessageDialog {

--- a/src/libgdar.hpp
+++ b/src/libgdar.hpp
@@ -39,7 +39,7 @@
 class ErrorMsg {
 public:
     ErrorMsg(Glib::ustring msg, Glib::ustring source);
-    ErrorMsg(libdar5::Egeneric &e);
+    ErrorMsg(LIBDAR::Egeneric &e);
     Glib::ustring msg;
     Glib::ustring source;
 };
@@ -73,7 +73,7 @@ public:
     void openDarThread();
     void populate();
 #ifdef GET_CHILDREN_IN_TABLE
-    void populate(std::vector<libdar5::list_entry> *children_table);
+    void populate(std::vector<LIBDAR::list_entry> *children_table);
 #endif
     void on_active_row(const Gtk::TreeModel::Path& path, Gtk::TreeViewColumn* column);
     void list_children_v();
@@ -111,12 +111,12 @@ protected:
     void create_mydar();
 
 private:
-    libdar5::statistics *extract_stats;
+    LIBDAR::statistics *extract_stats;
     bool is_open;
 
     std::queue<ErrorMsg> errorPipe;
 
-    libdar5::archive_options_read *read_options;
+    LIBDAR::archive_options_read *read_options;
 }; 
 
 class TableDialog : public Gtk::MessageDialog {

--- a/src/mylibdar.cpp
+++ b/src/mylibdar.cpp
@@ -27,7 +27,7 @@ using namespace std;
 using namespace libdar;
 
 Mydar::Mydar(Window *parentWindow): dialog(parentWindow) , dialog_custom_listing(parentWindow) {
-    crypt_algo = libdar5::crypto_none;
+    crypt_algo = LIBDAR::crypto_none;
 }
 Mydar::Mydar(Window *parentWindow, std::string path, std::string slice) : Mydar(parentWindow) {
     this->path = path;
@@ -38,7 +38,7 @@ Mydar::~Mydar() {
     if (my_statistic != NULL) {
         delete my_statistic;
     }
-//    libdar5::close_and_clean();
+//    LIBDAR::close_and_clean();
 }
 
 int Mydar::init() {
@@ -46,23 +46,23 @@ int Mydar::init() {
     //dialog_custom_listing = Dialog_custom_listing();
     my_statistic = NULL;
     stats_total = "";
-//    libdar5::U_I maj, med, min;
-    libdar5::U_16 excode;
+//    LIBDAR::U_I maj, med, min;
+    LIBDAR::U_16 excode;
     std::string msg;
 
-/*    libdar5::get_version(maj, med, min);
+/*    LIBDAR::get_version(maj, med, min);
 
-    if(maj != LIBDAR_COMPILE_TIME_MAJOR || med < libdar5::LIBDAR_COMPILE_TIME_MEDIUM) {
-        throw libdar5::Erange("initialization", "we are linking against a wrong libdar"); 
+    if(maj != LIBDAR_COMPILE_TIME_MAJOR || med < LIBDAR::LIBDAR_COMPILE_TIME_MEDIUM) {
+        throw LIBDAR::Erange("initialization", "we are linking against a wrong libdar"); 
     }*/
     return 0;
 }
 
-int Mydar::open(std::string path, std::string slice, libdar5::archive_options_read *read_options) {
+int Mydar::open(std::string path, std::string slice, LIBDAR::archive_options_read *read_options) {
     this->path = path;
     this->slice = slice;
 
-    my_arch = new libdar5::archive(dialog,path,slice, "dar", *read_options); 
+    my_arch = new LIBDAR::archive(dialog,path,slice, "dar", *read_options); 
 
 //    my_arch->init_catalogue(dialog); // not avalible in libdar v5.3.2
     return 0;
@@ -82,15 +82,15 @@ void Mydar::setListingBuffer(std::list<File> *buffer) {
     dialog_custom_listing.setListingBuffer(buffer);
 }
 
-int Mydar::extract(const char *dir, const char *dest,libdar5::statistics *stats) {
+int Mydar::extract(const char *dir, const char *dest,LIBDAR::statistics *stats) {
     string dir2 = dest;
     dir2 +=dir; // libdar expects the full path to where the dir will be extracted
     if (my_statistic != NULL) {
         delete my_statistic;
     }
 
-    libdar5::archive_options_extract options;
-    options.set_subtree(libdar5::simple_path_mask(dir2, true));
+    LIBDAR::archive_options_extract options;
+    options.set_subtree(LIBDAR::simple_path_mask(dir2, true));
     options.set_display_skipped(true);
     my_arch->op_extract(dialog,std::string(dest),options,stats);
 
@@ -103,27 +103,27 @@ int Mydar::count_files_in_dir(const char *dir) {
 
 /* load statistics of an already open archive */
 void Mydar::get_stats() {
-    libdar5::entree_stats my_stats = my_arch->get_stats();
-//    std::cout << "[+] total: " << libdar5::deci(my_stats.total).human() << std::endl;
+    LIBDAR::entree_stats my_stats = my_arch->get_stats();
+//    std::cout << "[+] total: " << LIBDAR::deci(my_stats.total).human() << std::endl;
 }
 
 /* 
  * test an already open archive
  */
 bool Mydar::test() {
-    libdar5::archive_options_test test_options;
-//    libdar5::statistics test_stats;
+    LIBDAR::archive_options_test test_options;
+//    LIBDAR::statistics test_stats;
     if (my_statistic != NULL) {
         delete my_statistic;
     }
-    libdar5::statistics test_stats = my_arch->op_test(dialog, test_options, NULL);
+    LIBDAR::statistics test_stats = my_arch->op_test(dialog, test_options, NULL);
 
     return true;
 }
 
 #ifdef GET_CHILDREN_IN_TABLE
-std::vector<libdar5::list_entry> Mydar::get_children_in_table(const std::string &dir) const {
-    std::vector<libdar5::list_entry> children_table;
+std::vector<LIBDAR::list_entry> Mydar::get_children_in_table(const std::string &dir) const {
+    std::vector<LIBDAR::list_entry> children_table;
     children_table = my_arch->get_children_in_table(dir);
     return children_table;
 }
@@ -138,7 +138,7 @@ void Mydar::set_crypto_pass(Glib::ustring pass) {
     this->pass = pass;
 }
 
-void Mydar::set_crypto_algo(libdar5::crypto_algo algo) {
+void Mydar::set_crypto_algo(LIBDAR::crypto_algo algo) {
     crypt_algo = algo;
 }
 

--- a/src/mylibdar.cpp
+++ b/src/mylibdar.cpp
@@ -92,8 +92,8 @@ int Mydar::extract(const char *dir, const char *dest,libdar5::statistics *stats)
     libdar5::archive_options_extract options;
     options.set_subtree(libdar5::simple_path_mask(dir2, true));
     options.set_display_skipped(true);
-    my_arch->op_extract(dialog,dest,options,stats);
-    
+    my_arch->op_extract(dialog,std::string(dest),options,stats);
+
     return 0;
 }
 

--- a/src/mylibdar.cpp
+++ b/src/mylibdar.cpp
@@ -27,7 +27,7 @@ using namespace std;
 using namespace libdar;
 
 Mydar::Mydar(Window *parentWindow): dialog(parentWindow) , dialog_custom_listing(parentWindow) {
-    crypt_algo = libdar::crypto_none;
+    crypt_algo = libdar5::crypto_none;
 }
 Mydar::Mydar(Window *parentWindow, std::string path, std::string slice) : Mydar(parentWindow) {
     this->path = path;
@@ -38,7 +38,7 @@ Mydar::~Mydar() {
     if (my_statistic != NULL) {
         delete my_statistic;
     }
-//    libdar::close_and_clean();
+//    libdar5::close_and_clean();
 }
 
 int Mydar::init() {
@@ -46,23 +46,23 @@ int Mydar::init() {
     //dialog_custom_listing = Dialog_custom_listing();
     my_statistic = NULL;
     stats_total = "";
-//    libdar::U_I maj, med, min;
-    libdar::U_16 excode;
+//    libdar5::U_I maj, med, min;
+    libdar5::U_16 excode;
     std::string msg;
 
-/*    libdar::get_version(maj, med, min);
+/*    libdar5::get_version(maj, med, min);
 
-    if(maj != LIBDAR_COMPILE_TIME_MAJOR || med < libdar::LIBDAR_COMPILE_TIME_MEDIUM) {
-        throw libdar::Erange("initialization", "we are linking against a wrong libdar"); 
+    if(maj != LIBDAR_COMPILE_TIME_MAJOR || med < libdar5::LIBDAR_COMPILE_TIME_MEDIUM) {
+        throw libdar5::Erange("initialization", "we are linking against a wrong libdar"); 
     }*/
     return 0;
 }
 
-int Mydar::open(std::string path, std::string slice, libdar::archive_options_read *read_options) {
+int Mydar::open(std::string path, std::string slice, libdar5::archive_options_read *read_options) {
     this->path = path;
     this->slice = slice;
 
-    my_arch = new libdar::archive(dialog,path,slice, "dar", *read_options); 
+    my_arch = new libdar5::archive(dialog,path,slice, "dar", *read_options); 
 
 //    my_arch->init_catalogue(dialog); // not avalible in libdar v5.3.2
     return 0;
@@ -82,15 +82,15 @@ void Mydar::setListingBuffer(std::list<File> *buffer) {
     dialog_custom_listing.setListingBuffer(buffer);
 }
 
-int Mydar::extract(const char *dir, const char *dest,libdar::statistics *stats) {
+int Mydar::extract(const char *dir, const char *dest,libdar5::statistics *stats) {
     string dir2 = dest;
     dir2 +=dir; // libdar expects the full path to where the dir will be extracted
     if (my_statistic != NULL) {
         delete my_statistic;
     }
 
-    libdar::archive_options_extract options;
-    options.set_subtree(libdar::simple_path_mask(dir2, true));
+    libdar5::archive_options_extract options;
+    options.set_subtree(libdar5::simple_path_mask(dir2, true));
     options.set_display_skipped(true);
     my_arch->op_extract(dialog,dest,options,stats);
     
@@ -103,27 +103,27 @@ int Mydar::count_files_in_dir(const char *dir) {
 
 /* load statistics of an already open archive */
 void Mydar::get_stats() {
-    libdar::entree_stats my_stats = my_arch->get_stats();
-//    std::cout << "[+] total: " << libdar::deci(my_stats.total).human() << std::endl;
+    libdar5::entree_stats my_stats = my_arch->get_stats();
+//    std::cout << "[+] total: " << libdar5::deci(my_stats.total).human() << std::endl;
 }
 
 /* 
  * test an already open archive
  */
 bool Mydar::test() {
-    libdar::archive_options_test test_options;
-//    libdar::statistics test_stats;
+    libdar5::archive_options_test test_options;
+//    libdar5::statistics test_stats;
     if (my_statistic != NULL) {
         delete my_statistic;
     }
-    libdar::statistics test_stats = my_arch->op_test(dialog, test_options, NULL);
+    libdar5::statistics test_stats = my_arch->op_test(dialog, test_options, NULL);
 
     return true;
 }
 
 #ifdef GET_CHILDREN_IN_TABLE
-std::vector<libdar::list_entry> Mydar::get_children_in_table(const std::string &dir) const {
-    std::vector<libdar::list_entry> children_table;
+std::vector<libdar5::list_entry> Mydar::get_children_in_table(const std::string &dir) const {
+    std::vector<libdar5::list_entry> children_table;
     children_table = my_arch->get_children_in_table(dir);
     return children_table;
 }
@@ -138,7 +138,7 @@ void Mydar::set_crypto_pass(Glib::ustring pass) {
     this->pass = pass;
 }
 
-void Mydar::set_crypto_algo(libdar::crypto_algo algo) {
+void Mydar::set_crypto_algo(libdar5::crypto_algo algo) {
     crypt_algo = algo;
 }
 

--- a/src/mylibdar.hpp
+++ b/src/mylibdar.hpp
@@ -40,10 +40,10 @@ namespace libdar = libdar5;
 
 class Mydar {
 public:
-    libdar::archive *my_arch;
+    libdar5::archive *my_arch;
     Dialog dialog;
     Dialog_custom_listing dialog_custom_listing;
-    libdar::U_16 exception;
+    libdar5::U_16 exception;
     std::string except_msg;
     std::string stats_total;
     std::string path;
@@ -55,15 +55,15 @@ public:
     // init libdar
     int init();
     // open dar archive
-    int open(std::string path, std::string slice, libdar::archive_options_read *read_options);
+    int open(std::string path, std::string slice, libdar5::archive_options_read *read_options);
     // list archive content
 //    int list();
     // list only children of parent dir
     int list_children(const char *dir);
 #ifdef GET_CHILDREN_IN_TABLE
-    std::vector<libdar::list_entry> get_children_in_table ( const std::string & dir) const;
+    std::vector<libdar5::list_entry> get_children_in_table ( const std::string & dir) const;
 #endif
-    int extract(const char *dir,const char *dest,libdar::statistics *stats);
+    int extract(const char *dir,const char *dest,libdar5::statistics *stats);
     int count_files_in_dir(const char *dir);
     void get_stats();
     bool test();
@@ -71,11 +71,11 @@ public:
     void setListingBuffer(std::list<File> *buffer);
 private:
 //    std::string get_slice(std::string path);
-    libdar::statistics *my_statistic;
+    libdar5::statistics *my_statistic;
     // security
     int block_size;
     Glib::ustring pass;
-    libdar::crypto_algo crypt_algo;
+    libdar5::crypto_algo crypt_algo;
     Window *parentWindow;
 };
 

--- a/src/mylibdar.hpp
+++ b/src/mylibdar.hpp
@@ -25,7 +25,6 @@
 #include "config.h"
 #ifdef LIBDAR5
 #include <dar/libdar5.hpp>
-namespace libdar = libdar5;
 #else
 #include <dar/libdar.hpp>
 #endif

--- a/src/mylibdar.hpp
+++ b/src/mylibdar.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
     gdar - a graphical user interface to browse and extract dar archives
     Copyright (C) 2017  Tobias Specht
 
@@ -23,11 +23,7 @@
 #define MYLIBDAR_HPP
 
 #include "config.h"
-#ifdef LIBDAR5
-#include <dar/libdar5.hpp>
-#else
-#include <dar/libdar.hpp>
-#endif
+#include "libdar_namespace.hpp"
 #include <dar/deci.hpp>
 #include <libintl.h>
 #include "myuser_interaction.hpp"
@@ -39,10 +35,10 @@
 
 class Mydar {
 public:
-    libdar5::archive *my_arch;
+    LIBDAR::archive *my_arch;
     Dialog dialog;
     Dialog_custom_listing dialog_custom_listing;
-    libdar5::U_16 exception;
+    LIBDAR::U_16 exception;
     std::string except_msg;
     std::string stats_total;
     std::string path;
@@ -54,15 +50,15 @@ public:
     // init libdar
     int init();
     // open dar archive
-    int open(std::string path, std::string slice, libdar5::archive_options_read *read_options);
+    int open(std::string path, std::string slice, LIBDAR::archive_options_read *read_options);
     // list archive content
 //    int list();
     // list only children of parent dir
     int list_children(const char *dir);
 #ifdef GET_CHILDREN_IN_TABLE
-    std::vector<libdar5::list_entry> get_children_in_table ( const std::string & dir) const;
+    std::vector<LIBDAR::list_entry> get_children_in_table ( const std::string & dir) const;
 #endif
-    int extract(const char *dir,const char *dest,libdar5::statistics *stats);
+    int extract(const char *dir,const char *dest,LIBDAR::statistics *stats);
     int count_files_in_dir(const char *dir);
     void get_stats();
     bool test();
@@ -70,11 +66,11 @@ public:
     void setListingBuffer(std::list<File> *buffer);
 private:
 //    std::string get_slice(std::string path);
-    libdar5::statistics *my_statistic;
+    LIBDAR::statistics *my_statistic;
     // security
     int block_size;
     Glib::ustring pass;
-    libdar5::crypto_algo crypt_algo;
+    LIBDAR::crypto_algo crypt_algo;
     Window *parentWindow;
 };
 

--- a/src/myuser_interaction.cpp
+++ b/src/myuser_interaction.cpp
@@ -23,7 +23,7 @@
 #include "myuser_interaction.hpp"
 
 using namespace std;
-using namespace libdar;
+using namespace LIBDAR;
 
 
 void Dialog::pause(const std::string & message) {
@@ -39,14 +39,14 @@ std::string Dialog::get_string(const std::string & message, bool echo) {
     return "";
 }
 
-libdar5::secu_string Dialog::get_secu_string(const std::string &message, bool echo) {
+LIBDAR::secu_string Dialog::get_secu_string(const std::string &message, bool echo) {
     //cout << "get_secu_string: " << message << endl;
     parentWindow->dialog_mutex.lock();
     parentWindow->show_pwd_dialog_disp();
     {
     Glib::Threads::Mutex::Lock lock(parentWindow->dialog_mutex);
     }
-    libdar5::secu_string s(parentWindow->dialog_secu_string.c_str(),parentWindow->dialog_secu_string.length());
+    LIBDAR::secu_string s(parentWindow->dialog_secu_string.c_str(),parentWindow->dialog_secu_string.length());
     return s;
 }
 

--- a/src/myuser_interaction.cpp
+++ b/src/myuser_interaction.cpp
@@ -39,14 +39,14 @@ std::string Dialog::get_string(const std::string & message, bool echo) {
     return "";
 }
 
-libdar::secu_string Dialog::get_secu_string(const std::string &message, bool echo) {
+libdar5::secu_string Dialog::get_secu_string(const std::string &message, bool echo) {
     //cout << "get_secu_string: " << message << endl;
     parentWindow->dialog_mutex.lock();
     parentWindow->show_pwd_dialog_disp();
     {
     Glib::Threads::Mutex::Lock lock(parentWindow->dialog_mutex);
     }
-    libdar::secu_string s(parentWindow->dialog_secu_string.c_str(),parentWindow->dialog_secu_string.length());
+    libdar5::secu_string s(parentWindow->dialog_secu_string.c_str(),parentWindow->dialog_secu_string.length());
     return s;
 }
 

--- a/src/myuser_interaction.hpp
+++ b/src/myuser_interaction.hpp
@@ -34,17 +34,17 @@ namespace libdar = libdar5;
 #include <iostream>
 
 
-class Dialog : public libdar::user_interaction {
+class Dialog : public libdar5::user_interaction {
 public:
     std::list<File> *listingBuffer;
     void pause(const std::string & message);
     void warning(const std::string & message);
     std::string get_string(const std::string & message, bool echo);
-    libdar::secu_string get_secu_string(const std::string &message, bool echo);
+    libdar5::secu_string get_secu_string(const std::string &message, bool echo);
     void warning_callback(const std::string &x, void *context);
     bool answer_callback(const std::string &x, void *context);
     std::string string_callback(const std::string &x, bool echo, void *context);
-    libdar::secu_string sec_string_callback(const std::string &x, bool echo, void *context);
+    libdar5::secu_string sec_string_callback(const std::string &x, bool echo, void *context);
     Dialog(Window *parentWindow);
     ~Dialog();
     Dialog *clone() const;

--- a/src/myuser_interaction.hpp
+++ b/src/myuser_interaction.hpp
@@ -27,7 +27,6 @@
 #include "file.hpp"
 #ifdef LIBDAR5
 #include <dar/libdar5.hpp>
-namespace libdar = libdar5;
 #else
 #include <dar/libdar.hpp>
 #endif

--- a/src/myuser_interaction.hpp
+++ b/src/myuser_interaction.hpp
@@ -25,25 +25,21 @@
 #include "config.h"
 #include "window.hpp"
 #include "file.hpp"
-#ifdef LIBDAR5
-#include <dar/libdar5.hpp>
-#else
-#include <dar/libdar.hpp>
-#endif
+#include "libdar_namespace.hpp"
 #include <iostream>
 
 
-class Dialog : public libdar5::user_interaction {
+class Dialog : public LIBDAR::user_interaction {
 public:
     std::list<File> *listingBuffer;
     void pause(const std::string & message);
     void warning(const std::string & message);
     std::string get_string(const std::string & message, bool echo);
-    libdar5::secu_string get_secu_string(const std::string &message, bool echo);
+    LIBDAR::secu_string get_secu_string(const std::string &message, bool echo);
     void warning_callback(const std::string &x, void *context);
     bool answer_callback(const std::string &x, void *context);
     std::string string_callback(const std::string &x, bool echo, void *context);
-    libdar5::secu_string sec_string_callback(const std::string &x, bool echo, void *context);
+    LIBDAR::secu_string sec_string_callback(const std::string &x, bool echo, void *context);
     Dialog(Window *parentWindow);
     ~Dialog();
     Dialog *clone() const;

--- a/src/pwd_dialog.hpp
+++ b/src/pwd_dialog.hpp
@@ -25,7 +25,6 @@
 #include <glibmm/i18n.h>
 #ifdef LIBDAR5
 #include <dar/libdar5.hpp>
-namespace libdar = libdar5;
 #else
 #include <dar/libdar.hpp>
 #endif


### PR DESCRIPTION
Hello Tobias,

Note that I had to add an alias in libdar5 namespace for gdar to be able to compile, so you need to use the latest code from dar/libdar git repository on branch_2.6.x to have the changes proposed within this pull request getting gdar compiling and running with libdar 2.6.x

Regards,
Denis